### PR TITLE
Workshop improvements

### DIFF
--- a/Combine.playground/Pages/Combining Publishers.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Combining Publishers.xcplaygroundpage/Contents.swift
@@ -8,18 +8,15 @@ import Combine
  - Merge multiple streams into one
  - Listen to multiple publishers
  */
-enum FormError: Error { }
 
-let usernamePublisher = PassthroughSubject<String, FormError>()
-let passwordPublisher = PassthroughSubject<String, FormError>()
+// Subjects simulate input from text fields
+let usernamePublisher = PassthroughSubject<String, Never>()
+let passwordPublisher = PassthroughSubject<String, Never>()
 
 let validatedCredentials = Publishers.CombineLatest(usernamePublisher, passwordPublisher)
-    .map { (username, password) -> (String, String) in
-        return (username, password)
-    }
-    .map({ (username, password) -> Bool in
+    .map { (username, password) -> Bool in
         !username.isEmpty && !password.isEmpty && password.count > 12
-    })
+    }
     .replaceError(with: false)
     .sink { (valid) in
         print("CombineLatest: Are the credentials valid: \(valid)")

--- a/Combine.playground/Pages/Debugging.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Debugging.xcplaygroundpage/Contents.swift
@@ -18,17 +18,18 @@ enum ExampleError: Swift.Error {
  Can be used combined with breakpoints for further insights.
  */
 let subject = PassthroughSubject<String, ExampleError>()
-let subscription = subject.handleEvents(receiveSubscription: { (subscription) in
-    print("Receive subscription")
-}, receiveOutput: { output in
-    print("Received output: \(output)")
-}, receiveCompletion: { _ in
-    print("Receive completion")
-}, receiveCancel: {
-    print("Receive cancel")
-}, receiveRequest: { demand in
-    print("Receive request: \(demand)")
-}).replaceError(with: "Error occurred").sink { _ in }
+let subscription = subject
+	.handleEvents(receiveSubscription: { (subscription) in
+		print("Receive subscription")
+	}, receiveOutput: { output in
+		print("Received output: \(output)")
+	}, receiveCompletion: { _ in
+		print("Receive completion")
+	}, receiveCancel: {
+		print("Receive cancel")
+	}, receiveRequest: { demand in
+		print("Receive request: \(demand)")
+	}).replaceError(with: "Error occurred").sink { _ in }
 
 subject.send("Hello!")
 subscription.cancel()
@@ -46,7 +47,10 @@ subscription.cancel()
  Using the print operator to log messages for all publishing events.
  */
 
-let printSubscription = subject.print("Print example").replaceError(with: "Error occurred").sink { _ in }
+let printSubscription = subject
+	.print("Print example")
+	.replaceError(with: "Error occurred")
+	.sink { _ in }
 
 subject.send("Hello!")
 printSubscription.cancel()

--- a/Combine.playground/Pages/Flatmap and error types.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Flatmap and error types.xcplaygroundpage/Contents.swift
@@ -13,10 +13,12 @@ enum RequestError: Error {
 }
 
 let URLPublisher = PassthroughSubject<URL, RequestError>()
-let anyCancellable = URLPublisher.flatMap { requestURL in
-    return URLSession.shared.dataTaskPublisher(for: requestURL)
+
+let subscription = URLPublisher.flatMap { requestURL in
+    URLSession.shared
+		.dataTaskPublisher(for: requestURL)
         .mapError { error -> RequestError in
-            return RequestError.sessionError(error: error)
+            RequestError.sessionError(error: error)
         }
     }
     .assertNoFailure()
@@ -24,6 +26,6 @@ let anyCancellable = URLPublisher.flatMap { requestURL in
         print("Request finished!")
         _ = UIImage(data: result.data)
     }
+
 URLPublisher.send(URL(string: "https://httpbin.org/image/jpeg")!)
 //: [Next](@next)
-

--- a/Combine.playground/Pages/Foundation and Combine.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Foundation and Combine.xcplaygroundpage/Contents.swift
@@ -5,19 +5,22 @@ import UIKit
 /*:
  [Previous](@previous)
  ## Foundation and Combine
- Foundation adds Combine implementations to standard types, like:
+ Foundation adds Combine publishers for many types, like:
  */
 /*:
  ##### A URLSessionTask publisher and a JSON Decoding operator
  */
 struct DecodableExample: Decodable { }
+
 URLSession.shared.dataTaskPublisher(for: URL(string: "https://www.avanderlee.com/feed/")!)
     .map { $0.data }
     .decode(type: DecodableExample.self, decoder: JSONDecoder())
+
 /*:
  ##### A Publisher for notifications
  */
 NotificationCenter.default.publisher(for: .NSSystemClockDidChange)
+
 /*:
  ##### KeyPath binding to NSObject instances
  */

--- a/Combine.playground/Pages/Future and Promises.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Future and Promises.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@ import Combine
 /*:
  [Previous](@previous)
  ## Future and Promises
- A `Publishers.Future` creates a new `Publisher` that eventually produces one value and then finishes or fails.
+ A `Publishers.Future` creates a new `Publisher` that eventually produces one value and then finishes, or fails.
  - Allows you to call custom methods and return a Result.success or Result.failure
  */
 struct User {
@@ -41,10 +41,10 @@ fetchUserPublisher
         }
     }
     .map { user in user.name }
-    .catch({ (error) -> Just<String> in
+    .catch { (error) -> Just<String> in
         print("Error occurred: \(error)")
         return Just("Not found")
-    })
+    }
     .sink { result in
         print("User is \(result)")
     }

--- a/Combine.playground/Pages/Memory Management.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Memory Management.xcplaygroundpage/Contents.swift
@@ -1,10 +1,10 @@
 import Foundation
-import UIKit
 import Combine
+import UIKit
 /*:
  [Previous](@previous)
  ## Memory Management
- Correct memory management using the `AnyCancellable` makes sure you're not retaining any references.
+ Correct memory management using `Cancellable` makes sure you're not retaining any references.
  */
 final class HomeViewController: UIViewController {
 
@@ -21,15 +21,13 @@ final class HomeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let foregroundSubscriberCanceller = NotificationCenter.default.publisher(for: .NSExtensionHostWillEnterForeground)
-            .handleEvents(receiveCancel: {
-                print("Foreground subscriber cancelled!")
-            })
+        foregroundSubscriber = NotificationCenter.default
+			.publisher(for: .NSExtensionHostWillEnterForeground)
+			.print("foregroundSubscriber")
             .sink { [unowned self] _ in
                 print("Reloading tableview!")
                 self.tableView.reloadData()
             }
-        foregroundSubscriber = AnyCancellable(foregroundSubscriberCanceller)
     }
 }
 

--- a/Combine.playground/Pages/Operators.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Operators.xcplaygroundpage/Contents.swift
@@ -1,0 +1,35 @@
+//: [Previous](@previous)
+
+import Foundation
+import Combine
+/*:
+[Previous](@previous)
+## Operators
+- Operators are functions defined on publisher instances...
+- ... each operator returns a new publisher ...
+- ... operators can be chained to add processing steps
+*/
+
+let publisher1 = PassthroughSubject<Int, Never>()
+
+let publisher2 = publisher1.map { value in
+	value + 100
+}
+
+let subscription1 = publisher1
+	.sink { value in
+		print("Subscription1 received integer: \(value)")
+}
+
+let subscription2 = publisher2
+	.sink { value in
+		print("Subscription2 received integer: \(value)")
+}
+
+print("Publisher1 emits 28")
+publisher1.send(28)
+
+print("Publisher1 emits 50")
+publisher1.send(50)
+
+//: [Next](@next)

--- a/Combine.playground/Pages/Publishers & Subscribers.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Publishers & Subscribers.xcplaygroundpage/Contents.swift
@@ -2,22 +2,17 @@ import Foundation
 import Combine
 /*:
  [Previous](@previous)
- ## Publishers, Operators, and Subscribers
- - A Publisher exposes values that can change on which..
- - .. change through operators and ..
- - ..a subscriber subscribes to receive all those updates
+ ## Publishers and Subscribers
+ - A Publisher _publishes_ values ...
+ - .. a subscriber _subscribes_ to receive publisher's values
 
  */
 let publisher = Just(28)
 
-// This creates a `Subscriber` on the `Just a 28` Publisher
-publisher
-    // We change the value
-    .map { number in
-        return "Antoine's age is \(number)"
-    }
-    // We subscribe using `sink`
-    .sink { (value) in
-        print(value)
+// We want to receive values from this publisher
+let subscription = publisher
+	// A sink subscribes to a publisher
+    .sink { value in
+        print("Received value: \(value)")
     }
 //: [Next](@next)

--- a/Combine.playground/Pages/Rules of subscriptions.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Rules of subscriptions.xcplaygroundpage/Contents.swift
@@ -4,6 +4,7 @@
  - A subscriber will receive a _single_ subscription
  - _Zero_ or _more_ values can be published
  - At most _one_ completion will be called
+ - After completion, nothing more is received
  */
 import Combine
 import UIKit
@@ -13,6 +14,9 @@ enum ExampleError: Swift.Error {
 }
 
 let subject = PassthroughSubject<String, ExampleError>()
+
+// the handleEvents operator lets you intercept
+// all stages of a subscription lifecycle
 subject.handleEvents(receiveSubscription: { (subscription) in
         print("New subscription!")
     }, receiveOutput: { _ in
@@ -24,7 +28,7 @@ subject.handleEvents(receiveSubscription: { (subscription) in
     })
     .replaceError(with: "Failure")
     .sink { (value) in
-        print("Subscriber one received value: \(value)")
+        print("Subscriber received value: \(value)")
     }
 
 subject.send("Hello!")

--- a/Combine.playground/Pages/Rules of subscriptions.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Rules of subscriptions.xcplaygroundpage/Contents.swift
@@ -16,7 +16,7 @@ enum ExampleError: Swift.Error {
 let subject = PassthroughSubject<String, ExampleError>()
 
 // The handleEvents operator lets you intercept
-// all stages of a subscription lifecycle
+// All stages of a subscription lifecycle
 subject.handleEvents(receiveSubscription: { (subscription) in
         print("New subscription!")
     }, receiveOutput: { _ in

--- a/Combine.playground/Pages/Rules of subscriptions.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Rules of subscriptions.xcplaygroundpage/Contents.swift
@@ -15,7 +15,7 @@ enum ExampleError: Swift.Error {
 
 let subject = PassthroughSubject<String, ExampleError>()
 
-// the handleEvents operator lets you intercept
+// The handleEvents operator lets you intercept
 // all stages of a subscription lifecycle
 subject.handleEvents(receiveSubscription: { (subscription) in
         print("New subscription!")

--- a/Combine.playground/Pages/Subjects.xcplaygroundpage/Contents.swift
+++ b/Combine.playground/Pages/Subjects.xcplaygroundpage/Contents.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Combine
+/*:
+ [Previous](@previous)
+ ## Subjects
+ - A subject is both a subscriber and a publisher ...
+- ... relays values it receives from other publishers ...
+- ... can be manually fed with new values
+ */
+let subject = PassthroughSubject<String, Never>()
+
+let subscription = subject
+	.sink { value in
+		print("Received value: \(value)")
+}
+
+// Manually send a value through the subject
+subject.send("Hello!")
+
+// Subscribe the subject to a publisher, it relays the values
+let publisher = Just("Here we go")
+publisher.subscribe(subject)
+
+//: [Next](@next)

--- a/Combine.playground/contents.xcplayground
+++ b/Combine.playground/contents.xcplayground
@@ -3,6 +3,8 @@
     <pages>
         <page name='What is Combine'/>
         <page name='Publishers &amp; Subscribers'/>
+        <page name='Subjects'/>
+        <page name='Operators'/>
         <page name='Rules of subscriptions'/>
         <page name='Foundation and Combine'/>
         <page name='@Published properties'/>


### PR DESCRIPTION
Here are several changes to existing pages, two new pages to separately introduce subjects and operators, and one remark: IMHO in the context of this workshop I think the Custom UIKit Publishers page is not needed, and should be at least be located after the debugging page.
